### PR TITLE
Rental validation

### DIFF
--- a/app/models/bookingsync_portal/remote_rental.rb
+++ b/app/models/bookingsync_portal/remote_rental.rb
@@ -10,7 +10,7 @@ class BookingsyncPortal::RemoteRental < ActiveRecord::Base
 
   serialize :remote_data, BookingsyncPortal::MashSerializer
 
-  validates :uid, presence: true, uniqueness: true
+  validates :uid, uniqueness: { allow_nil: true }
   validates :remote_account, presence: true
 
   scope :ordered, -> { order(created_at: :desc) }

--- a/spec/models/remote_rental_spec.rb
+++ b/spec/models/remote_rental_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe BookingsyncPortal.remote_rental_model.constantize do
   it { is_expected.to have_one(:connection).dependent(:destroy) }
   it { is_expected.to have_one(:rental).through(:connection) }
 
-  it { is_expected.to validate_presence_of(:uid) }
-  it { is_expected.to validate_uniqueness_of(:uid) }
+  it { is_expected.to validate_uniqueness_of(:uid).allow_nil }
   it { is_expected.to validate_presence_of(:remote_account) }
 
   describe '#connected?' do


### PR DESCRIPTION
do not validate presence on remote_rental uid to allow remote creation