### PR TITLE
Creating source while creating invalid remote_account, will result in an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Ensure proper source sync for invalid create remote_accounts calls
+
 # 0.8.0
 
 * Disconnect rentals without reloading page

--- a/app/controllers/bookingsync_portal/admin/remote_accounts_controller.rb
+++ b/app/controllers/bookingsync_portal/admin/remote_accounts_controller.rb
@@ -8,8 +8,8 @@ module BookingsyncPortal
       end
 
       def create
-        @remote_account = scope.create(params_remote_account)
         BookingsyncPortal::Write::EnsureSourceExists.new(current_account).call
+        @remote_account = scope.create(params_remote_account)
         respond_with @remote_account, location: admin_rentals_url
       end
 


### PR DESCRIPTION
I was able to resolve it by moving this [line](https://github.com/BookingSync/bookingsync_portal/blob/master/app/controllers/bookingsync_portal/admin/remote_accounts_controller.rb#L12) before
 `@remote_account = scope.create(params_remote_account)`

I think that doing the update from [here](https://github.com/BookingSync/bookingsync_portal/blob/master/app/synchronizers/bookingsync_portal/write/ensure_source_exists.rb#L20), while we are with an invalid `remote_account` object is causing rails to go nuts. 