### PR TITLE
add hook for custom includes

### DIFF
--- a/app/controllers/bookingsync_portal/admin/rentals_controller.rb
+++ b/app/controllers/bookingsync_portal/admin/rentals_controller.rb
@@ -9,7 +9,7 @@ module BookingsyncPortal
         @visible_rentals = current_account.rentals.visible
         @remote_accounts = current_account.remote_accounts
         @remote_rentals_by_account = current_account.remote_rentals.ordered
-          .includes(:remote_account).group_by(&:remote_account)
+          .with_custom_includes.group_by(&:remote_account)
       end
 
       def show

--- a/app/models/bookingsync_portal/remote_rental.rb
+++ b/app/models/bookingsync_portal/remote_rental.rb
@@ -16,6 +16,7 @@ class BookingsyncPortal::RemoteRental < ActiveRecord::Base
   scope :ordered, -> { order(created_at: :desc) }
   scope :connected, -> { joins(:rental) }
   scope :not_connected, -> { includes(:rental).where(rentals: { id: nil }) }
+  scope :with_custom_includes, -> { includes(:remote_account, :rental) }
 
   def display_name
     uid


### PR DESCRIPTION
There are some terrible N+1 when rendering index due to `remote_rental.rental` for each connected rental. This should fix it and will also provide opportunity to override and add some additional includes if view is more complex. 