### PR TITLE
include rentals on rentals#index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### master
 
 * Update appraisal gemfiles
+* Fix N+1 query by including rentals on rentals#index
 
 ### 0.9.0 - 2016-12-25
 

--- a/app/controllers/bookingsync_portal/admin/rentals_controller.rb
+++ b/app/controllers/bookingsync_portal/admin/rentals_controller.rb
@@ -9,7 +9,7 @@ module BookingsyncPortal
         @visible_rentals = current_account.rentals.visible
         @remote_accounts = current_account.remote_accounts
         @remote_rentals_by_account = current_account.remote_rentals.ordered
-          .includes(:remote_account).group_by(&:remote_account)
+          .includes(:remote_account, :rental).group_by(&:remote_account)
       end
 
       def show


### PR DESCRIPTION
As suggested this hook in the model was not the best idea, so here is just small improvement that will help to remove N+1 query from index action. Proper fix suggested by @Azdaroth would require lot of work but I don't think we have time for it now, so just go with this for now.