### PR TITLE
require at least rails 5

### DIFF
--- a/bookingsync_portal.gemspec
+++ b/bookingsync_portal.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails'
+  s.add_dependency 'rails', '~> 5'
   s.add_dependency 'sprockets-rails'
   s.add_dependency 'responders'
   s.add_dependency 'bookingsync_application', '~> 0.5.0'


### PR DESCRIPTION
The changelog says 1.0 dropped support for rails versions prior to 5, but the gemspec does not.