### PR TITLE
add placeholder for warning message

### DIFF
--- a/app/assets/stylesheets/bookingsync_portal/admin/application.css.scss
+++ b/app/assets/stylesheets/bookingsync_portal/admin/application.css.scss
@@ -239,3 +239,11 @@ body > .footer {
     background-color: #fff;
   }
 }
+
+.alert-top {
+  margin-bottom: -71px;
+  padding-top: 85px;
+  @media screen and (max-width: 767px) {
+    padding-top: 150px;
+  }
+}

--- a/app/views/layouts/bookingsync_portal/_warning_top.html.erb
+++ b/app/views/layouts/bookingsync_portal/_warning_top.html.erb
@@ -1,0 +1,5 @@
+<%- if yield(:warning_top).present? -%>
+  <div class="alert alert-warning alert-top" role="alert">
+    <%= yield(:warning_top) %>
+  </div>
+<%- end -%>

--- a/app/views/layouts/bookingsync_portal/admin.html.erb
+++ b/app/views/layouts/bookingsync_portal/admin.html.erb
@@ -11,6 +11,7 @@
 </head>
 <body data-messagebus-channel="<%= messagebus_channel %>">
   <%= render partial: '/layouts/bookingsync_portal/menu' %>
+  <%= render partial: '/layouts/bookingsync_portal/warning_top' %>
   <div class="container container-fullscreen">
     <%= render '/layouts/bookingsync_portal/flash' %>
     <%= yield %>


### PR DESCRIPTION
If content_for specified: 
![screen shot 2018-02-12 at 16 57 36](https://user-images.githubusercontent.com/6774970/36147831-0b031dac-10ba-11e8-9766-5e5e930d4230.jpg)
if not it will behave in the same way as currently
![screen shot 2018-02-12 at 16 59 07](https://user-images.githubusercontent.com/6774970/36147863-2927f730-10ba-11e8-9730-4b052f2729ad.jpg)
