### PR TITLE
[ignore for now][hotfix] - Skip search when no search query

### DIFF
--- a/app/controllers/bookingsync_portal/admin/rentals_controller.rb
+++ b/app/controllers/bookingsync_portal/admin/rentals_controller.rb
@@ -101,17 +101,24 @@ module BookingsyncPortal
       end
 
       def apply_search
-        BookingsyncPortal.filter_strategies.each do |strategy|
-          @action_variables.not_connected_rentals = strategy.constantize.call(
-            account: current_account, 
-            records: @action_variables.not_connected_rentals, 
-            search_filter: search_filter
-          )
-          @action_variables.remote_rentals = strategy.constantize.call(
-            account: current_account,
-            records: @action_variables.remote_rentals, 
-            search_filter: search_filter
-          )
+        if search_by_rentals?
+          BookingsyncPortal.filter_strategies.each do |strategy|
+            @action_variables.not_connected_rentals = strategy.constantize.call(
+              account: current_account,
+              records: @action_variables.not_connected_rentals,
+              search_filter: search_filter
+            )
+          end
+        end
+
+        if search_by_remote_rentals?
+          BookingsyncPortal.filter_strategies.each do |strategy|
+            @action_variables.remote_rentals = strategy.constantize.call(
+              account: current_account,
+              records: @action_variables.remote_rentals,
+              search_filter: search_filter
+            )
+          end
         end
       end
 

--- a/spec/controllers/admin/rentals_controller_spec.rb
+++ b/spec/controllers/admin/rentals_controller_spec.rb
@@ -363,5 +363,16 @@ describe BookingsyncPortal::Admin::RentalsController do
         end
       end
     end
+
+    context "when rentals_search or remote_rentals_search query is not used" do
+      let(:params) { {} }
+
+      it "calls only filters strategies for remote account" do
+        expect(BookingsyncPortal::Searcher).to receive(:call).with(query: "", records: [remote_account_empty], search_settings: {:numeric=>["uid"]}).and_call_original
+        expect(BookingsyncPortal::Searcher).not_to receive(:call)
+
+        index_with_search
+      end
+    end
   end
 end


### PR DESCRIPTION
Based on PP with @darthjee we have found out that we run search even when there are no search params(like on initial load), when running specs with 500 rentals and remote rentals this proved to cause issues with performance, since running one spec took around ~8s.
It would be good to try this out, to at least have some improvements for PM to show.

We have noticed possible issue with search but that will require more time to fix so thinking to try this simple change for now.