### PR TITLE
Skip blank remote accounts for large accounts

### DIFF
--- a/app/controllers/bookingsync_portal/admin/rentals_controller.rb
+++ b/app/controllers/bookingsync_portal/admin/rentals_controller.rb
@@ -34,7 +34,9 @@ module BookingsyncPortal
       end
 
       def ignore_blank_remote_accounts?
-        search_filter.remote_rentals_query.blank? && search_filter.remote_rentals_page > 1
+        return false if search_filter.remote_rentals_query.present?
+
+        search_filter.remote_rentals_page > 1 || BookingsyncPortal.ignore_blank_remote_accounts_for_account.call(current_account)
       end
 
       def action_variables

--- a/lib/bookingsync_portal.rb
+++ b/lib/bookingsync_portal.rb
@@ -106,6 +106,10 @@ module BookingsyncPortal
   mattr_accessor :rentals_synchronizer
   @@rentals_synchronizer = ->(account) { BookingsyncPortal.rental_model.constantize.synchronize(scope: account) }
 
+  # Enable controlling display of blank remote accounts
+  mattr_accessor :ignore_blank_remote_accounts_for_account
+  @@ignore_blank_remote_accounts_for_account = ->(account) { false }
+
   # fetch remote rentals
   def self.fetch_remote_rentals(account)
     # return false if remote account is not present or not valid

--- a/spec/controllers/admin/rentals_controller_spec.rb
+++ b/spec/controllers/admin/rentals_controller_spec.rb
@@ -103,7 +103,7 @@ describe BookingsyncPortal::Admin::RentalsController do
       context "when configuration is set to not ignore blank remote accounts" do
         it "assigns all remote accounts" do
           index_with_search
-          expect(assigns(:remote_accounts).count).to include(*blank_remote_accounts)
+          expect(assigns(:remote_accounts)).to include(*blank_remote_accounts)
         end
       end
 

--- a/spec/controllers/admin/rentals_controller_spec.rb
+++ b/spec/controllers/admin/rentals_controller_spec.rb
@@ -103,7 +103,7 @@ describe BookingsyncPortal::Admin::RentalsController do
       context "when configuration is set to not ignore blank remote accounts" do
         it "assigns all remote accounts" do
           index_with_search
-          expect(assigns(:remote_accounts).count).to eq(26)
+          expect(assigns(:remote_accounts).count).to include(*blank_remote_accounts)
         end
       end
 
@@ -116,12 +116,12 @@ describe BookingsyncPortal::Admin::RentalsController do
 
         it "ignores blank remote accounts on first page" do
           index_with_search
-          expect(assigns(:remote_accounts).count).to eq(2)
+          expect(assigns(:remote_accounts)).not_to include(*blank_remote_accounts)
         end
 
-        context "when search" do
+        context "when there is a search query" do
           let!(:blank_remote_account_to_search) { blank_remote_accounts.first }
-          let(:remote_rentals_search_query) { "#{blank_remote_account_to_search.uid}" }
+          let(:remote_rentals_search_query) { blank_remote_account_to_search.uid.to_s }
 
           it "displays searched remote account" do
             index_with_search

--- a/spec/controllers/admin/rentals_controller_spec.rb
+++ b/spec/controllers/admin/rentals_controller_spec.rb
@@ -100,34 +100,32 @@ describe BookingsyncPortal::Admin::RentalsController do
     context "when there is large amount of blank remote accounts" do
       let!(:blank_remote_accounts) { create_list(:remote_account, 23, account: account) }
 
-      context "when on first page" do
-        context "when configuration is set to not ignore blank remote accounts" do
-          it "assigns all remote accounts" do
-            index_with_search
-            expect(assigns(:remote_accounts).count).to eq(26)
-          end
+      context "when configuration is set to not ignore blank remote accounts" do
+        it "assigns all remote accounts" do
+          index_with_search
+          expect(assigns(:remote_accounts).count).to eq(26)
+        end
+      end
+
+      context "when configuration is set to ignore blank remote accounts" do
+        around do |example|
+          BookingsyncPortal.ignore_blank_remote_accounts_for_account = ->(_) { true }
+          example.run
+          BookingsyncPortal.ignore_blank_remote_accounts_for_account = ->(_) { false }
         end
 
-        context "when configuration is set to ignore blank remote accounts" do
-          around do |example|
-            BookingsyncPortal.ignore_blank_remote_accounts_for_account = ->(_) { true }
-            example.run
-            BookingsyncPortal.ignore_blank_remote_accounts_for_account = ->(_) { false }
-          end
+        it "ignores blank remote accounts on first page" do
+          index_with_search
+          expect(assigns(:remote_accounts).count).to eq(2)
+        end
 
-          it "ignores blank remote accounts on first page" do
+        context "when search" do
+          let!(:blank_remote_account_to_search) { blank_remote_accounts.first }
+          let(:remote_rentals_search_query) { "#{blank_remote_account_to_search.uid}" }
+
+          it "displays searched remote account" do
             index_with_search
-            expect(assigns(:remote_accounts).count).to eq(2)
-          end
-
-          context "when search" do
-            let!(:blank_remote_account_to_search) { blank_remote_accounts.first }
-            let(:remote_rentals_search_query) { "#{blank_remote_account_to_search.uid}" }
-
-            it "displays searched remote account" do
-              index_with_search
-              expect(assigns(:remote_accounts)).to contain_exactly(blank_remote_account_to_search)
-            end
+            expect(assigns(:remote_accounts)).to contain_exactly(blank_remote_account_to_search)
           end
         end
       end


### PR DESCRIPTION
### [Story](https://bookingsync.atlassian.net/browse/CMA-96563)

### Additional comments

Then app should configure this in `config/bookginsync_portal.rb`

```ruby
config.ignore_blank_remote_accounts_for_account = ->(account) { use policy or some custom logic)
```