### PR TITLE
Widen jquery-ui-rails version constraint

### DIFF
--- a/bookingsync_portal.gemspec
+++ b/bookingsync_portal.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'redis'
   # FIXME: Will no longer be needed once UI moved to Ember
   s.add_dependency 'jquery-rails'
-  s.add_dependency 'jquery-ui-rails', '~> 6.0.1'
+  s.add_dependency 'jquery-ui-rails', '>= 6.0.1'
   s.add_dependency 'bootstrap-sass', '< 3.5'
   s.add_dependency 'bootstrap-bookingsync-sass', '~> 3.0.0'
   s.add_dependency 'font-awesome-sass', '4.7.0'


### PR DESCRIPTION
## Summary
- Change `jquery-ui-rails` dependency from `~> 6.0.1` to `>= 6.0.1` so consuming apps can pick up jquery-ui-rails 7.x and 8.x.
- jquery-ui-rails 7.x / 8.x bundle jQuery UI 1.13.x, which fixes several moderate XSS advisories present in 1.12.x: GHSA-h6gj-6jjq-h8g9 (checkboxradio), GHSA-9gj3-hwp5-pmwc / GHSA-j7qv-pgf6-hvh4 (Datepicker `*Text` and `altField`), GHSA-gpqq-952q-5327 (`.position()` `of`).
- Constraint widening is purely additive — apps still locked to 6.x in their `Gemfile.lock` will keep resolving there until they explicitly bump.

## Audit
This gem only pulls in two jQuery UI widgets via the Sprockets manifest:
- `jquery-ui/widgets/draggable`
- `jquery-ui/widgets/droppable`

None of the breakage surfaces between jQuery UI 1.12 and 1.13 (`Datepicker` `*Text` HTML escaping, `checkboxradio` label sanitization, `.position()` `of` strict typing, `jQuery.uniqueId` removal, custom theme path/class shifts) are touched by this gem's code, stylesheets, or specs. CSS only references stable `.ui-draggable` / `.ui-draggable-dragging` hooks.

## Test plan
- [x] Existing rspec suite (87 examples) passes against jquery-ui-rails 6.0.1
- [x] Existing rspec suite (87 examples) passes against jquery-ui-rails 7.0
- [x] Existing rspec suite (87 examples) passes against jquery-ui-rails 8.0
- [x] `bookingsync_portal/admin/application.js` Sprockets manifest compiles cleanly under each version with draggable/droppable widget code present in the bundle